### PR TITLE
Feat: Display total active job count on home page

### DIFF
--- a/app/Http/Controllers/Api/JobController.php
+++ b/app/Http/Controllers/Api/JobController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Job; // Assuming Job model maps to jobs_employment table
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB; // Required for now() typically, though Carbon is preferred
+
+class JobController extends Controller
+{
+    /**
+     * Get the count of active jobs.
+     *
+     * An active job is one that has not passed its expiration_date or has a null expiration_date.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function activeCount(): JsonResponse
+    {
+        // Using Carbon\Carbon::now() is generally preferred over DB::raw('now()') for testability and flexibility
+        $now = \Carbon\Carbon::now();
+
+        $count = Job::where(function ($query) use ($now) {
+            $query->where('expiration_date', '>', $now)
+                  ->orWhereNull('expiration_date');
+        })->count();
+
+        return response()->json(['active_job_count' => $count]);
+    }
+}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -10,6 +10,7 @@
             <p class="text-xl text-blue-100 mb-12 max-w-2xl mx-auto">
                 Connecting talented students and graduates with exciting opportunities from leading employers. Your next career move starts here.
             </p>
+            <p class="text-lg text-blue-200 mt-4 mb-8"><span id="active-job-count-placeholder">Loading...</span> vagas disponíveis!</p>
             <div class="space-x-4">
                 <a href="{{ route('jobs.index') }}"
                    class="bg-yellow-400 hover:bg-yellow-500 text-gray-800 font-bold py-3 px-8 rounded-lg text-lg shadow-lg transform hover:scale-105 transition duration-300">
@@ -70,3 +71,32 @@
         </div>
     </div>
 @endsection
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        fetch('/api/jobs/active-count')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(data => {
+                const countElement = document.getElementById('active-job-count-placeholder');
+                if (countElement && data.active_job_count !== undefined) {
+                    countElement.textContent = data.active_job_count;
+                } else if (countElement) {
+                    countElement.textContent = 'N/A';
+                }
+            })
+            .catch(error => {
+                console.error('Error fetching active job count:', error);
+                const countElement = document.getElementById('active-job-count-placeholder');
+                if (countElement) {
+                    countElement.textContent = '-'; // Or some other error indicator
+                }
+            });
+    });
+</script>
+@endpush

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,9 @@ Route::post('/reset-password', [AuthController::class, 'resetPassword'])->name('
 Route::get('/email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])
     ->middleware('signed')
     ->name('verification.verify');
+
+Route::get('/jobs/active-count', [App\Http\Controllers\Api\JobController::class, 'activeCount'])->name('api.jobs.active_count');
+
 // Route::middleware(['auth:api', 'role:admin,superadmin'])->group(function () {
     // Route::get('/admin/dashboard', [AdminController::class, 'dashboard']); // Moved to superadmin group
     // Note: Original task asked for superadmin only for user management.

--- a/tests/Feature/Api/JobApiTest.php
+++ b/tests/Feature/Api/JobApiTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Job;
+use App\Models\User; // Required if JobFactory creates users or for other setup
+use App\Models\AreaOfInterest; // Required if JobFactory creates areas of interest
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JobApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test the active job count endpoint.
+     *
+     * @return void
+     */
+    public function test_active_job_count_endpoint_returns_correct_count(): void
+    {
+        // Create active jobs
+        Job::factory()->count(3)->create(['expiration_date' => now()->addDays(5)]);
+
+        // Create active jobs with null expiration date
+        Job::factory()->count(2)->create(['expiration_date' => null]);
+
+        // Create inactive jobs
+        Job::factory()->count(4)->create(['expiration_date' => now()->subDays(5)]);
+
+        // Make a GET request to the API endpoint
+        $response = $this->getJson('/api/jobs/active-count');
+
+        // Assert the response status is 200 (OK)
+        $response->assertStatus(200);
+
+        // Assert the JSON response contains the correct active job count
+        $response->assertJson(['active_job_count' => 5]); // 3 (future) + 2 (null)
+    }
+
+    /**
+     * Test the active job count endpoint when there are no active jobs.
+     *
+     * @return void
+     */
+    public function test_active_job_count_endpoint_returns_zero_when_no_active_jobs(): void
+    {
+        // Create only inactive jobs
+        Job::factory()->count(4)->create(['expiration_date' => now()->subDays(5)]);
+
+        // Make a GET request to the API endpoint
+        $response = $this->getJson('/api/jobs/active-count');
+
+        // Assert the response status is 200 (OK)
+        $response->assertStatus(200);
+
+        // Assert the JSON response contains 0 active jobs
+        $response->assertJson(['active_job_count' => 0]);
+    }
+
+    /**
+     * Test the active job count endpoint when there are no jobs at all.
+     *
+     * @return void
+     */
+    public function test_active_job_count_endpoint_returns_zero_when_no_jobs_exist(): void
+    {
+        // No jobs created
+
+        // Make a GET request to the API endpoint
+        $response = $this->getJson('/api/jobs/active-count');
+
+        // Assert the response status is 200 (OK)
+        $response->assertStatus(200);
+
+        // Assert the JSON response contains 0 active jobs
+        $response->assertJson(['active_job_count' => 0]);
+    }
+}


### PR DESCRIPTION
I've implemented a feature to show the total number of currently active job vacancies on the site's home page.

Changes include:

1.  **Backend API Endpoint:**
    *   I added a new route `GET /api/jobs/active-count`.
    *   I created `App\Http\Controllers\Api\JobController` with an `activeCount` method.
    *   The method counts jobs from the `jobs_employment` table where the `expiration_date` is in the future or is `NULL`.
    *   It returns a JSON response: `{"active_job_count": <count>}`.

2.  **Frontend Display:**
    *   I modified `resources/views/welcome.blade.php` (the home page).
    *   I added a placeholder to display the count.
    *   I included JavaScript (using `@push('scripts')`) to fetch the count from the new API endpoint on DOMContentLoaded and update the placeholder.
    *   Basic error handling is included in the script (displays 'N/A' or '-' on error).

3.  **Tests:**
    *   I added feature tests in `tests/Feature/Api/JobApiTest.php` for the `/api/jobs/active-count` endpoint.
    *   These tests cover scenarios with:
        *   A mix of active (future and null expiration dates) and inactive (past expiration date) jobs.
        *   Only inactive jobs.
        *   No jobs in the database.
    *   All tests ensure the endpoint returns the correct count and a 200 status.