### PR TITLE
Fix: Correct role assignment for company registration

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -8,7 +8,7 @@
             <form method="POST" action="{{ route('register.store') }}" enctype="multipart/form-data">
                 @csrf
                 {{-- Hidden role input, value set by controller via $type --}}
-                <input type="hidden" name="role" value="{{ $type ?? old('role', 'student') }}">
+                <input type="hidden" name="role" value="{{ ($type === 'company') ? 'employer' : ($type ?? old('role', 'student')) }}">
 
                 <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Create Your Account as {{ ucfirst($type ?? 'User') }}</h2>
 


### PR DESCRIPTION
I modified `resources/views/auth/register.blade.php` to ensure that when you register via the 'company' registration type link, the hidden 'role' input field is correctly set to 'employer'.

Previously, a type of 'company' was incorrectly submitting 'company' as the role, which did not align with the backend validation expecting 'employer'. This change maps `$type = 'company'` to `role = 'employer'` in the form, allowing company registrations to be processed with the correct role.